### PR TITLE
chore: add ocamlformat file

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,0 @@
-version=0.26.2
-profile=conventional


### PR DESCRIPTION
**PR**: Refactors the` .ocamlformat` file into the root of `terminal_screen' project.

With `.ocamlformat` on the repository's root it can not be discovered by the continuous integration workflow.