### PR TITLE
chore: add ocamlformat file

### DIFF
--- a/terminal_screen/.ocamlformat
+++ b/terminal_screen/.ocamlformat
@@ -1,0 +1,2 @@
+version=0.26.2
+profile=conventional


### PR DESCRIPTION
**PR**: Refactors the `.ocamlformat` file into the root of `terminal_screen' project.

With `.ocamlformat` in the repository's root it can not be discovered by the continuous integration workflow.