### PR TITLE
feat: draw supplied char on a screen buffer

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,4 +1,4 @@
 (executable
- (public_name terminal_screen)
+ (public_name terminal_screen_app)
  (name main)
  (libraries terminal_screen))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,6 +1,8 @@
 open Terminal_screen.Screen
+open Terminal_screen.Draw_character
 
 let () =
+  (* Setup the screen *)
   let example_setup_data = [| 80; 25; 0x02 |] in
   try
     setup_screen example_setup_data;
@@ -12,5 +14,30 @@ let () =
         | Monochrome -> "Monochrome"
         | SixteenColours -> "16 Colours"
         | TwoHundredAndFiftySixColours -> "256 Colours")
-    else Printf.printf "Screen is not initialized.\n"
-  with Failure msg -> Printf.printf "Error: %s\n" msg
+    else Printf.printf "Screen is not initialized.\n";
+
+    (* Draw characters on the screen *)
+    let draw_data_list =
+      [
+        [| 10; 5; 0x01; Char.code 'A' |];
+        [| 15; 10; 0x02; Char.code 'B' |];
+        [| 30; 5; 0x03; Char.code 'C' |];
+      ]
+    in
+    List.iter
+      (fun draw_data ->
+        try draw_character draw_data
+        with Failure msg -> Printf.printf "Error: %s\n" msg)
+      draw_data_list;
+
+    (* Display the screen buffer *)
+    Printf.printf "Screen buffer:\n";
+    let screen_buffer = get_screen_buffer () in
+    let state = get_screen_state () in
+    for y = 0 to state.height - 1 do
+      for x = 0 to state.width - 1 do
+        Printf.printf "%c" screen_buffer.(y).(x)
+      done;
+      Printf.printf "\n"
+    done
+  with Failure msg -> Printf.printf "Error during screen setup: %s\n" msg

--- a/lib/draw_character.ml
+++ b/lib/draw_character.ml
@@ -1,0 +1,21 @@
+open Screen
+
+let draw_character data =
+  if Array.length data <> 4 then
+    failwith "Invalid data length for draw character"
+  else if not (is_ready ()) then failwith "Screen is not initialized"
+  else
+    let x = data.(0) in
+    let y = data.(1) in
+    let colour_index = data.(2) in
+    let character = Char.chr data.(3) in
+
+    let state = get_screen_state () in
+    if x < 0 || x >= state.width || y < 0 || y >= state.height then
+      failwith "Coordinates are out of bounds"
+    else
+      let screen_buffer = get_screen_buffer () in
+      (* Array.set (!screen_buffer).(y) (x) character; *)
+      screen_buffer.(y).(x) <- character;
+      Printf.printf "Drawing character '%c' at (%d, %d) with colour %d\n"
+        character x y colour_index

--- a/lib/draw_character.mli
+++ b/lib/draw_character.mli
@@ -1,0 +1,13 @@
+val draw_character : int array -> unit
+(** [draw_character data] draws a character on the terminal screen.
+    [data] is an array of bytes where:
+    - [data.(0)] is the x-coordinate.
+    - [data.(1)] is the y-coordinate.
+    - [data.(2)] is the colour index (currently unused).
+    - [data.(3)] is the ASCII value of the character to draw.
+
+    Raises [Failure] if:
+    - The screen is not initialized.
+    - [data] has an invalid length.
+    - The coordinates are out of bounds.
+*)

--- a/lib/dune
+++ b/lib/dune
@@ -1,3 +1,4 @@
 (library
  (name terminal_screen)
- (public_name terminal_screen))
+ (public_name terminal_screen)
+ (modules Screen Draw_character Terminal_screen))

--- a/lib/screen.ml
+++ b/lib/screen.ml
@@ -11,12 +11,24 @@ let screen =
   ref
     { width = 0; height = 0; colour_mode = Monochrome; is_initialized = false }
 
+let screen_buffer = ref [||]
+let get_screen_buffer () = !screen_buffer
+
+let initialize_buffer width height =
+  screen_buffer := Array.make_matrix height width ' '
+
 let parse_colour_mode byte =
   match byte with
   | 0x00 -> Monochrome
   | 0x01 -> SixteenColours
   | 0x02 -> TwoHundredAndFiftySixColours
   | _ -> failwith "Invalid colour mode supplied"
+
+let get_screen_state () = !screen
+
+let initialize_screen_buffer () =
+  let state = get_screen_state () in
+  initialize_buffer state.width state.height
 
 let setup_screen data =
   if Array.length data <> 3 then failwith "Invalid data length for setup screen"
@@ -26,7 +38,7 @@ let setup_screen data =
     let colour_mode = parse_colour_mode data.(2) in
     if width <= 0 || height <= 0 then
       failwith "Invalid screen dimensions supplied"
-    else screen := { width; height; colour_mode; is_initialized = true }
+    else screen := { width; height; colour_mode; is_initialized = true };
+    initialize_screen_buffer ()
 
 let is_ready () = !screen.is_initialized
-let get_screen_state () = !screen

--- a/lib/screen.mli
+++ b/lib/screen.mli
@@ -1,12 +1,38 @@
-type colour_mode = Monochrome | SixteenColours | TwoHundredAndFiftySixColours
+(** Represents the colour mode of the screen. *)
+type colour_mode =
+  | Monochrome  (** Monochrome display mode. *)
+  | SixteenColours  (** 16 colours display mode. *)
+  | TwoHundredAndFiftySixColours  (** 256 colours display mode. *)
 
 type screen_state = {
-  width : int;
-  height : int;
-  colour_mode : colour_mode;
+  width : int;  (** The width of the screen in characters. *)
+  height : int;  (** The height of the screen in characters. *)
+  colour_mode : colour_mode;  (** The colour mode of the screen. *)
   is_initialized : bool;
+      (** Indicates whether the screen has been initialized. *)
 }
+(** Represents the state of the screen. *)
 
 val setup_screen : int array -> unit
+(** 
+  Initializes the screen with the given dimensions.
+  @param dimensions An array where the first element is the width and the second element is the height of the screen.
+*)
+
 val is_ready : unit -> bool
+(** 
+  Checks if the screen is ready for use.
+  @return true if the screen is initialized and ready, false otherwise.
+*)
+
 val get_screen_state : unit -> screen_state
+(** 
+  Retrieves the current state of the screen.
+  @return The current state of the screen as a [screen_state] record.
+*)
+
+val get_screen_buffer : unit -> char array array
+(** 
+  Retrieves the current screen buffer.
+  @return A 2D array of characters representing the current screen buffer.
+*)

--- a/lib/terminal_screen.ml
+++ b/lib/terminal_screen.ml
@@ -1,0 +1,2 @@
+module Screen = Screen
+module Draw_character = Draw_character

--- a/test/test_terminal_screen.ml
+++ b/test/test_terminal_screen.ml
@@ -1,4 +1,5 @@
 open Terminal_screen.Screen
+open Terminal_screen.Draw_character
 
 let test_setup_screen () =
   let test_data = [| 100; 30; 0x01 |] in
@@ -9,7 +10,19 @@ let test_setup_screen () =
   assert (state.height = 30);
   match state.colour_mode with SixteenColours -> () | _ -> assert false
 
-let test_cases = [ ("Test Setup Screen", `Quick, test_setup_screen) ]
+let test_draw_character () =
+  let test_data = [| 100; 30; 0x01 |] in
+  setup_screen test_data;
+  draw_character [| 10; 5; 0x01; Char.code 'A' |];
+
+  let screen_buffer = get_screen_buffer () in
+  assert (screen_buffer.(5).(10) = 'A')
+
+let test_cases =
+  [
+    ("Test Setup Screen", `Quick, test_setup_screen);
+    ("Test Draw Character", `Quick, test_draw_character);
+  ]
 
 let () =
   Printf.printf "Running tests...\n";


### PR DESCRIPTION
**PR**: **Screen Management and Character Drawing**
closes #2 

**Summary**
This PR introduces functionality for setting up and rendering a terminal screen, including managing the screen buffer and drawing characters at specific coordinates.

**Changes**
`screen.ml` & `screen.mli`:

Added setup_screen to initialize screen dimensions and color mode.
Exposed get_screen_buffer to access the screen buffer for drawing.

`draw_character.ml`:

- Implemented draw_character to place characters at specified coordinates on the screen.
- Added checks to ensure the screen is initialized before drawing.

`main.ml`:

- Integrated screen setup and character drawing in the main program.
- Added error handling for invalid inputs.

**How to Test**
- Run `dune exec terminal_screen_app`.
- The screen is initialised with dimensions `80x25` and 256 colors.
- Characters are drawn at positions `(10,5)`, `(15,10)`, and `(30,5)`.
- The screen buffer is printed with the characters placed correctly.