### PR TITLE
Add render_text Functionality for rendering strings on the screen

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,6 +1,7 @@
 open Terminal_screen.Screen
 open Terminal_screen.Draw_character
 open Terminal_screen.Draw_line
+open Terminal_screen.Render_text
 
 (* Function to print command instructions *)
 let print_instructions command =
@@ -24,6 +25,13 @@ let print_instructions command =
          coordinates), color index, and ASCII character code:\n\
          - Example: 5 10 15 20 9 42 (to draw a line from (0,0) to (20,10) with \
          colour index 9 using '*' character)\n"
+  | 0x4 ->
+      Printf.printf
+        "Render Text (Command 0x4):\n\
+         - Enter integers for x coordinate, y coordinate, colour index, \
+         followed by ASCII character codes:\n\
+         - Example 45 10 6 72 101 108 108 111 (to render 'Hello' at \
+         coordinates (45,10) with colour index 6)\n"
   | _ -> Printf.printf "Unknown command. Please try again.\n"
 
 (* Function to parse and execute commands *)
@@ -41,6 +49,10 @@ let execute_command command data =
       if Array.length data <> 6 then
         failwith "Invalid data length for draw line"
       else draw_line data
+  | 0x4 ->
+      if Array.length data < 4 then
+        failwith "Invalid data length for render text"
+      else render_text data
   | _ -> failwith "Unknown command"
 
 (* Function to display the screen *)
@@ -60,8 +72,10 @@ let display_screen () =
 (* Main function to process input *)
 let rec main () =
   Printf.printf
-    "Enter command (0x1 for setup, 0x2 for draw character, 0x3 for draw line, \
-     q to quit):\n";
+    "Enter command:\n\
+    \    (0x1 for setup, 0x2 for draw character,\n\
+    \    0x3 for draw line, 0x4 for render_text,\n\
+    \    q to quit):\n";
   let input = read_line () in
   if input = "q" then (
     Printf.printf "Exiting program.\n";

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name terminal_screen)
  (public_name terminal_screen)
- (modules Screen Draw_character Draw_line Terminal_screen))
+ (modules Screen Draw_character Draw_line Render_text Terminal_screen))

--- a/lib/render_text.ml
+++ b/lib/render_text.ml
@@ -1,0 +1,26 @@
+open Screen
+
+let render_text data =
+  if Array.length data < 4 then failwith "Invalid data for render text"
+  else
+    let x = data.(0) in
+    let y = data.(1) in
+    let colour_index = data.(2) in
+    let text = Array.sub data 3 (Array.length data - 3) in
+    let screen_state = get_screen_state () in
+    let screen_buffer = get_screen_buffer () in
+    let text_string =
+      Array.map (fun c -> String.make 1 (Char.chr c)) text
+      |> Array.to_list |> String.concat ""
+    in
+    let text_length = String.length text_string in
+
+    if x < 0 || y < 0 || x >= screen_state.width || y >= screen_state.height
+    then failwith "Text starting position is out of bounds"
+    else
+      for i = 0 to text_length - 1 do
+        let screen_x = x + i in
+        if screen_x < screen_state.width then
+          screen_buffer.(y).(screen_x) <- (text_string.[i], colour_index)
+        else ()
+      done

--- a/lib/render_text.mli
+++ b/lib/render_text.mli
@@ -1,0 +1,8 @@
+val render_text : int array -> unit
+(** [render_text arr] renders text based on the given integer array [arr].
+    Each integer in the array represents a character code or some form of
+    text representation. The function performs the rendering operation
+    without returning any value.
+
+    @param arr An array of integers representing the text to be rendered.
+*)

--- a/lib/terminal_screen.ml
+++ b/lib/terminal_screen.ml
@@ -1,3 +1,4 @@
 module Screen = Screen
 module Draw_character = Draw_character
 module Draw_line = Draw_line
+module Render_text = Render_text

--- a/test/test_terminal_screen.ml
+++ b/test/test_terminal_screen.ml
@@ -1,6 +1,7 @@
 open Terminal_screen.Screen
 open Terminal_screen.Draw_character
 open Terminal_screen.Draw_line
+open Terminal_screen.Render_text
 
 let test_setup_screen () =
   let test_data = [| 100; 30; 0x01 |] in
@@ -42,11 +43,38 @@ let test_draw_line () =
   assert (char_at_15_20 = '-');
   assert (colour_at_15_20 = 42)
 
+let test_render_text () =
+  let test_data = [| 100; 30; 0x02 |] in
+  setup_screen test_data;
+
+  render_text
+    [|
+      5;
+      10;
+      0x01;
+      Char.code 'H';
+      Char.code 'e';
+      Char.code 'l';
+      Char.code 'l';
+      Char.code 'o';
+    |];
+
+  let screen_buffer = get_screen_buffer () in
+  let expected_text = [ 'H'; 'e'; 'l'; 'l'; 'o' ] in
+  List.iteri
+    (fun i char ->
+      let screen_x = 5 + i in
+      let char_at_x_y, colour_mode = screen_buffer.(10).(screen_x) in
+      assert (char_at_x_y = char);
+      assert (colour_mode = 0x01))
+    expected_text
+
 let test_cases =
   [
     ("Test Setup Screen", `Quick, test_setup_screen);
     ("Test Draw Character", `Quick, test_draw_character);
     ("Test Draw Line", `Quick, test_draw_line);
+    ("Test Render Text", `Quick, test_render_text);
   ]
 
 let () =


### PR DESCRIPTION
This PR introduces the `render_text` functionality to the project. The new feature allows rendering a string of text starting from a specified position on the terminal screen. It integrates seamlessly with the existing screen rendering system and follows the same data-driven architecture.

**Changes Made**
New module: `render_text.ml`

- Implements the `render_text` function to handle the rendering of ASCII text starting at a given position with a specific colour.
- Accepts an array input in the following format:
Byte 0: X-coordinate
Byte 1: Y-coordinate
Byte 2: Colour index
Byte 3-n: ASCII text data
- Ensures robust handling of edge cases, such as rendering outside screen boundaries.

**Integration with `main.ml`**

- Added support for the `0x04` command to trigger the `render_text` functionality.
- Prints instructions for using the command in the CLI prompt.
- Displays the screen buffer after executing the command.

**Test Suite Updates**

- Added test to validate the correctness of the `render_text` function.
- Ensures proper placement of text on the screen buffer and checks that the colour mode is correctly applied.
