### PR TITLE
chore: correct 0x3 command documentation

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -25,8 +25,8 @@ let print_instructions command =
         "Draw Line (Command 0x3):\n\
          - Enter 6 integers: x1, y1 (starting coordinates), x2, y2 (ending \
          coordinates), color index, and ASCII character code:\n\
-         - Example: 5 10 15 20 9 42 (to draw a line from (0,0) to (20,10) with \
-         colour index 9 using '*' character)\n"
+         - Example: 5 10 15 20 9 42 (to draw a line from (5,10) to (15,20) \
+         with colour index 9 using '*' character)\n"
   | 0x4 ->
       Printf.printf
         "Render Text (Command 0x4):\n\


### PR DESCRIPTION
**PR: Correct Documentation for Drawing Line Command**

**Description**
- This PR corrects the example documentation for the "Draw Line" command (Command `0x3`) in the terminal screen rendering program. The example incorrectly described the coordinates for drawing a line, leading to confusion.

**Changes Made**
Updated Example:
From:
```bash
Draw Line (Command 0x3):
  - Enter 6 integers: x1, y1 (starting coordinates), x2, y2 (ending coordinates), color index, and ASCII character code.
  - Example: 5 10 15 20 9 42 (to draw a line from (0,0) to (20,10) with colour index 9 using '*' character)
```

To:

```bash
Draw Line (Command 0x3):
  - Enter 6 integers: x1, y1 (starting coordinates), x2, y2 (ending coordinates), colour index, and ASCII character code.
  - Example: 5 10 15 20 9 42 (to draw a line from (5, 10) to (15, 20) with colour index 9 using the '*' character, where 42 is the ASCII code for '*').
```

**Reason for Changes**
-The original example incorrectly described the line coordinates. The corrected example now accurately reflects how to draw a line from `(5, 10)` to `(15, 20)` using the specified colour and ASCII character, ensuring clearer understanding for users.